### PR TITLE
PSAAS-30912: enable Spur Context TLS verification by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2024-2025 Splunk Inc.
+   Copyright (c) 2024-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Spur Context
-Copyright (c) 2024-2025 Splunk Inc.
+Copyright (c) 2024-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Spur Context
 
-Publisher: Splunk Community \
-Connector Version: 1.0.2 \
-Product Vendor: Spur \
-Product Name: Context \
+Publisher: Splunk Community <br>
+Connector Version: 1.0.2 <br>
+Product Vendor: Spur <br>
+Product Name: Context <br>
 Minimum Product Version: 6.1.1
 
 The Spur Context API provides REST API access for IP Context data. Visit our website for more information on use-cases, integrations, and client successes
@@ -24,14 +24,14 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
 [lookup ip](#action-lookup-ip) - Check for the presence of an IP in a threat intelligence feed
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -46,7 +46,7 @@ No Output
 
 Check for the presence of an IP in a threat intelligence feed
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -94,7 +94,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Enables TLS certificate verification by default; existing assets using untrusted certificates must review their setting.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Enables TLS certificate verification by default; existing assets using untrusted certificates must review their setting.
+* Enables TLS certificate verification by default; existing assets using untrusted certificates must review their setting.

--- a/spurcontext.json
+++ b/spurcontext.json
@@ -11,7 +11,7 @@
     "fips_compliant": false,
     "product_version_regex": ".*",
     "publisher": "Splunk Community",
-    "license": "Copyright (c) 2024-2025 Splunk Inc.",
+    "license": "Copyright (c) 2024-2026 Splunk Inc.",
     "app_version": "1.0.2",
     "utctime_updated": "2025-04-28T19:33:08.019859Z",
     "package_name": "phantom_spurcontext",
@@ -39,7 +39,7 @@
         "verify_server_cert": {
             "description": "Verify server certificate",
             "data_type": "boolean",
-            "default": false,
+            "default": true,
             "order": 2
         }
     },
@@ -235,5 +235,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/spurcontext_connector.py
+++ b/spurcontext_connector.py
@@ -1,6 +1,6 @@
 # File: spurcontext_connector.py
 #
-# Copyright (c) 2024-2025 Splunk Inc.
+# Copyright (c) 2024-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ class SpurContextConnector(BaseConnector):
         headers = {"Token": config["api_token"]}
 
         try:
-            r = request_func(url, verify=config.get("verify_server_cert", False), headers=headers, **kwargs)
+            r = request_func(url, verify=config.get("verify_server_cert", True), headers=headers, **kwargs)
         except Exception as e:
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {e!s}"), resp_json)
 

--- a/spurcontext_consts.py
+++ b/spurcontext_consts.py
@@ -1,6 +1,6 @@
 # File: spurcontext_consts.py
 #
-# Copyright (c) 2024-2025 Splunk Inc.
+# Copyright (c) 2024-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Written by Codex.

## Summary

- Refreshes connector validation hooks and dev-cicd-tools to v2.2.4.
- Enables TLS certificate verification by default for new Spur Context assets and configurations that omit the setting.
- Regenerates connector documentation, metadata, dependency information, copyright headers, and release-note formatting with the current tooling.

## Impact

Assets using an untrusted certificate must explicitly disable **Verify server certificate**.

## Tracking

- PAPP-38073 (ESPM-5228)
- PSAAS-30912
- VULN-93637
- FS-1736

## Validation

- `pre-commit run --all-files --show-diff-on-failure` with isolated Python 3.13, public PyPI, and Docker: passed all hooks, including Semgrep, package-app-dependencies, and static tests.
- `git diff --check`: passed.